### PR TITLE
Update to version 2.3.1

### DIFF
--- a/com.prusa3d.PrusaSlicer.json
+++ b/com.prusa3d.PrusaSlicer.json
@@ -65,8 +65,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/prusa3d/PrusaSlicer/archive/version_2.3.0.tar.gz",
-                    "sha256": "cd3bac5e29b5441fc4690f28cd7b1064e97dc00207bbdc88f7bd7832308d6ca5"
+                    "url": "https://github.com/prusa3d/PrusaSlicer/archive/version_2.3.1.tar.gz",
+                    "sha256": "c1315826d07f428dfe4b9aa6325727beb1257aa6f711d1659a2760f8e213cd51"
                 }
             ]
         }

--- a/com.prusa3d.PrusaSlicer.metainfo.xml
+++ b/com.prusa3d.PrusaSlicer.metainfo.xml
@@ -50,6 +50,13 @@
     </screenshots>
     <content_rating type="oars-1.1" />
     <releases>
+        <release version="2.3.1" date="2021-04-19">
+            <description>
+                <p>This a final release of PrusaSlicer 2.3.1, introducing native builds for the new Apple Silicon MacBooks, Chrome OS support, performance improvements 
+                in G-code rendering, security fixes and new 3rd party printer profiles. For full changelog on PrusaSlicer 2.3.1 series, please check the PrusaSlicer 
+                2.3.1-rc change log.</p>
+            </description>
+        </release>
         <release version="2.3.0" date="2021-01-11">
             <description>
                 <p>This a final release of PrusaSlicer 2.3.0, introducing paint-on supports, ironing, monotonic infill, seam painting, adaptive and support cubic infill,


### PR DESCRIPTION
Hello,
I've bumped the version number for this flatpak to the most recently released one: [PrusaSlicer 2.3.1](https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.3.1). Please let me know if i've missed anything, i'd be happy to make any corrections needed