### PR TITLE
Update to version 2.3.2

### DIFF
--- a/com.prusa3d.PrusaSlicer.json
+++ b/com.prusa3d.PrusaSlicer.json
@@ -65,8 +65,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/prusa3d/PrusaSlicer/archive/version_2.3.1.tar.gz",
-                    "sha256": "c1315826d07f428dfe4b9aa6325727beb1257aa6f711d1659a2760f8e213cd51"
+                    "url": "https://github.com/prusa3d/PrusaSlicer/archive/version_2.3.2.tar.gz",
+                    "sha256": "1dfc9e6e0cbc23ee70cb8cedad08bc1683724cd8fc319f2b758a7aa8a449d65b"
                 }
             ]
         }

--- a/com.prusa3d.PrusaSlicer.metainfo.xml
+++ b/com.prusa3d.PrusaSlicer.metainfo.xml
@@ -50,6 +50,16 @@
     </screenshots>
     <content_rating type="oars-1.1" />
     <releases>
+        <release version="2.3.2" date="2021-07-08">
+            <description>
+                <p>This is a final release of PrusaSlicer 2.3.2, following 2.3.2-beta and 2.3.2-rc. 
+                For the new features in the 2.3.2 series, please read the change logs of the beta and release candidate. 
+                The final release is functionally equal to the release candidate, with a single additional improvement:
+                Before installing profile updates, a configuration snapshot is taken. In rare circumstances when the current configuration is not consistent, 
+                taking a configuration snapshot fails. PrusaSlicer 2.3.2 newly informs about the issue and offers either to install the configuration updates 
+                even if taking the configuration snapshot failed or to abort update of the profiles.</p>
+            </description>
+        </release>
         <release version="2.3.1" date="2021-04-19">
             <description>
                 <p>This a final release of PrusaSlicer 2.3.1, introducing native builds for the new Apple Silicon MacBooks, Chrome OS support, performance improvements 

--- a/dependencies/boost.json
+++ b/dependencies/boost.json
@@ -8,7 +8,7 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2",
+            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.bz2",
             "sha256": "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7"
         }
     ],


### PR DESCRIPTION
I also updated the download link for boost, as bintray.com seems to no longer be a thing and releases are now available on boostorg.jfrog.io.