### PR TITLE
Update to version 2.3.3

### DIFF
--- a/com.prusa3d.PrusaSlicer.json
+++ b/com.prusa3d.PrusaSlicer.json
@@ -65,8 +65,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/prusa3d/PrusaSlicer/archive/version_2.3.2.tar.gz",
-                    "sha256": "1dfc9e6e0cbc23ee70cb8cedad08bc1683724cd8fc319f2b758a7aa8a449d65b"
+                    "url": "https://github.com/prusa3d/PrusaSlicer/archive/version_2.3.3.tar.gz",
+                    "sha256": "deda209505f740ac3d6f59cb2a960f4df908269ee09bd30cd4edb9fc472d29ac"
                 }
             ]
         }

--- a/com.prusa3d.PrusaSlicer.metainfo.xml
+++ b/com.prusa3d.PrusaSlicer.metainfo.xml
@@ -50,6 +50,12 @@
     </screenshots>
     <content_rating type="oars-1.1" />
     <releases>
+        <release version="2.3.3" date="2021-07-16">
+            <description>
+                <p>PrusaSlicer 2.3.3 is a patch release following PrusaSlicer 2.3.2 release, fixing an unfortunate bug in handling FDM multi-material 
+                project and configuration files #6711.</p>
+            </description>
+        </release>
         <release version="2.3.2" date="2021-07-08">
             <description>
                 <p>This is a final release of PrusaSlicer 2.3.2, following 2.3.2-beta and 2.3.2-rc. 


### PR DESCRIPTION
Upstream [issued a new PrusaSlicer version due to a bug](https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.3.3), this update is based on that change