### PR TITLE
Add quotation marks to the file path

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -17,5 +17,5 @@ fi
     export GTK_THEME='Adwaita:dark' &&
     echo "Message: $(date +%T): INFO: using dark theme variant"
 
-exec /app/bin/prusa-slicer $@ &
+exec /app/bin/prusa-slicer "$@" &
 $(/app/bin/set-dark-theme-variant.py) &


### PR DESCRIPTION
If I double-click on file with an extension configured to be open with PrusaSlicer and file path contains spaces PrusaSlicer don't start.

Add quotation mark to file path in entrypoint script resolve this.