### PR TITLE
upgrade python-xlib to 0.33

### DIFF
--- a/com.prusa3d.PrusaSlicer.yml
+++ b/com.prusa3d.PrusaSlicer.yml
@@ -50,8 +50,8 @@ modules:
       - pip3 install --no-deps --no-build-isolation --verbose --prefix=${FLATPAK_DEST} .
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/40/9c/107e22f637d33434404c07d69112b9d26b76ee0dd4dd705131ab6cdcc818/python-xlib-0.31.tar.gz
-        sha256: 74d83a081f532bc07f6d7afcd6416ec38403d68f68b9b9dc9e1f28fbf2d799e9
+        url: https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz
+        sha256: 55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32
   
   - name: glu
     config-opts:


### PR DESCRIPTION
Starting from fedora 37 the envirorment variable to set the dark theme works partially (the title bar remains with clear theme) this is caused by a [bug in python-xlib](https://github.com/python-xlib/python-xlib/issues/225) fixed in newer versions