### PR TITLE
Add access to gvfs

### DIFF
--- a/com.prusa3d.PrusaSlicer.yml
+++ b/com.prusa3d.PrusaSlicer.yml
@@ -15,6 +15,7 @@ finish-args:
   - --share=network
   - --device=all
   - --filesystem=home
+  - --filesystem=xdg-run/gvfs # make GnomeVFS accessible
   - --filesystem=/run/media
   - --filesystem=/media
   # Allow PrusaSlicer to own its session bus. 


### PR DESCRIPTION
Filesystem "xdg-run/gvfs" is needed in order to access gvfs (e.g. smb file shares mounted via gnome files).

This change is only tested via flatseal. I copied the line from [FreeCAD](https://github.com/flathub/org.freecadweb.FreeCAD/blob/master/org.freecadweb.FreeCAD.yaml) so the syntax should be fine.