### PR TITLE
 update org.freedesktop.Platform to 23.08

### DIFF
--- a/com.prusa3d.PrusaSlicer.yml
+++ b/com.prusa3d.PrusaSlicer.yml
@@ -1,6 +1,6 @@
 app-id: com.prusa3d.PrusaSlicer
 runtime: org.freedesktop.Platform
-runtime-version: "21.08"
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 command: entrypoint
 separate-locales: true

--- a/patches/TBB/GNU.cmake
+++ b/patches/TBB/GNU.cmake
@@ -26,7 +26,8 @@ else()
     set(TBB_DEF_FILE_PREFIX lin${TBB_ARCH})
 endif()
 
-set(TBB_WARNING_LEVEL -Wall -Wextra $<$<BOOL:${TBB_STRICT}>:-Werror> -Wfatal-errors)
+# Add -Wno-error=stringop-overflow to fix GCC 12+ build as suggested on https://github.com/oneapi-src/oneTBB/issues/843#issuecomment-1152646035
+set(TBB_WARNING_LEVEL -Wall -Wextra $<$<BOOL:${TBB_STRICT}>:-Werror> -Wfatal-errors -Wno-error=stringop-overflow)
 set(TBB_TEST_WARNING_FLAGS -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor)
 
 # Depfile options (e.g. -MD) are inserted automatically in some cases.

--- a/patches/add_printables_com_desktop_integration_support_for_flatpak_builds_PR_11229.patch
+++ b/patches/add_printables_com_desktop_integration_support_for_flatpak_builds_PR_11229.patch
@@ -1,37 +1,39 @@
-From 7896532dca6b5dfa66d5de2062fc12472ca29e62 Mon Sep 17 00:00:00 2001
+From b919b5bd0ed9922376afd8dee753e77fbd706821 Mon Sep 17 00:00:00 2001
 From: Elia Devito <eliadevito@gmail.com>
 Date: Sat, 2 Sep 2023 12:22:18 +0200
 Subject: [PATCH] add support for flatpak in
  perform_downloader_desktop_integration
 
 ---
- src/slic3r/GUI/DesktopIntegrationDialog.cpp | 16 ++++++++++++----
- 1 file changed, 12 insertions(+), 4 deletions(-)
+ src/slic3r/GUI/DesktopIntegrationDialog.cpp | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
 
 diff --git a/src/slic3r/GUI/DesktopIntegrationDialog.cpp b/src/slic3r/GUI/DesktopIntegrationDialog.cpp
-index 031001978a..a6a5e24b8e 100644
+index 031001978..78f9ed0e9 100644
 --- a/src/slic3r/GUI/DesktopIntegrationDialog.cpp
 +++ b/src/slic3r/GUI/DesktopIntegrationDialog.cpp
-@@ -467,6 +467,7 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
+@@ -467,6 +467,8 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
      BOOST_LOG_TRIVIAL(debug) << "performing downloader desktop integration.";
      // Path to appimage
      const char* appimage_env = std::getenv("APPIMAGE");
 +    const char* container_env = std::getenv("container");
++	bool is_flatpak = false;
      std::string excutable_path;
      if (appimage_env) {
          try {
-@@ -478,6 +479,10 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
+@@ -478,6 +480,11 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
              return;
          }
      }
-+    else if (strcmp(container_env, "flatpak") == 0) {
++    else if (container_env && strcmp(container_env, "flatpak") == 0) {
++		is_flatpak = true;
 +        const char* flatpak_id = std::getenv("FLATPAK_ID");
 +        excutable_path = "flatpak run " + std::string(flatpak_id);
 +    }
      else {
          // not appimage - find executable
          excutable_path = boost::dll::program_location().string();
-@@ -491,9 +496,12 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
+@@ -491,9 +498,12 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
          }
      }
  
@@ -39,7 +41,7 @@ index 031001978a..a6a5e24b8e 100644
 -    //boost::replace_all(excutable_path, "'", "'\\''");
 -    excutable_path = escape_string(excutable_path);
 +    // For flatpak there are not required neither quotes nor escape
-+    if (strcmp(container_env, "flatpak") != 0) {
++    if (!is_flatpak) {
 +        // Escape ' characters in appimage, other special symbols will be esacaped in desktop file by 'excutable_path'
 +        //boost::replace_all(excutable_path, "'", "'\\''");
 +        excutable_path = "\"" + escape_string(excutable_path) + "\"";
@@ -47,7 +49,7 @@ index 031001978a..a6a5e24b8e 100644
  
      // Find directories icons and applications
      // $XDG_DATA_HOME defines the base directory relative to which user specific data files should be stored. 
-@@ -539,7 +547,7 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
+@@ -539,7 +549,7 @@ void DesktopIntegrationDialog::perform_downloader_desktop_integration()
      std::string desktop_file_downloader = GUI::format(
          "[Desktop Entry]\n"
          "Name=PrusaSlicer URL Protocol%1%\n"
@@ -56,3 +58,6 @@ index 031001978a..a6a5e24b8e 100644
          "Terminal=false\n"
          "Type=Application\n"
          "MimeType=x-scheme-handler/prusaslicer;\n"
+-- 
+2.41.0
+


### PR DESCRIPTION
CHANGELOG:
- Sync add_printables_com_desktop_integration_support patch with the [upstream PR version](https://github.com/prusa3d/PrusaSlicer/pull/11229)
- Update org.freedesktop.Platform to 23.08 (fix #87)