### PR TITLE
Update com.prusa3d.PrusaSlicer.yml -> org.freedesktop.Platform branch 21.08 is end-of-life!

### DIFF
--- a/com.prusa3d.PrusaSlicer.yml
+++ b/com.prusa3d.PrusaSlicer.yml
@@ -1,6 +1,6 @@
 app-id: com.prusa3d.PrusaSlicer
 runtime: org.freedesktop.Platform
-runtime-version: "21.08"
+runtime-version: "23.08.2"
 sdk: org.freedesktop.Sdk
 command: entrypoint
 separate-locales: true

--- a/com.prusa3d.PrusaSlicer.yml
+++ b/com.prusa3d.PrusaSlicer.yml
@@ -1,6 +1,6 @@
 app-id: com.prusa3d.PrusaSlicer
 runtime: org.freedesktop.Platform
-runtime-version: "23.08.2"
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 command: entrypoint
 separate-locales: true

--- a/com.prusa3d.PrusaSlicer.yml
+++ b/com.prusa3d.PrusaSlicer.yml
@@ -1,6 +1,6 @@
 app-id: com.prusa3d.PrusaSlicer
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "22.08"
 sdk: org.freedesktop.Sdk
 command: entrypoint
 separate-locales: true


### PR DESCRIPTION
The org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates, because the runtime org.freedesktop.Platform branch 21.08 is end-of-life!